### PR TITLE
Added more plugins to armorstand tick detection

### DIFF
--- a/cogs/timings_check.yml
+++ b/cogs/timings_check.yml
@@ -384,6 +384,8 @@ config:
     armor-stands-tick:
     - expressions:
       - paper["world-settings"]["default"]["armor-stands-tick"] == "true"
+      - '"Train_Carts" not in plugins'
+      - '"Animatronics" not in plugins'
       - '"PetBlocks" not in plugins'
       - '"BlockBalls" not in plugins'
       - '"ArmorStandTools" not in plugins'


### PR DESCRIPTION
Animatronics and Train_Carts use moving armorstands, so disabling armorstand tick causes bugs.