### PR TITLE
Adds wiki indexing and command shortcuts

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,7 @@ if use_wiki_commands:
           if wikis[key] not in use_wikis:
               wikis[key] = "none"
       wiki.set_wiki(wikis)
-   except ImportError:
+    except ImportError:
       print("Unable to import wiki functions. Is the file in your directory?")
 
 # Import subprocess

--- a/bot.py
+++ b/bot.py
@@ -15,14 +15,10 @@ use_wiki_commands = True # toggle
 use_wikis = ["example"]  # specific toggle (included => on)
 if use_wiki_commands:
     try:
-      import wiki
-      wikis = wiki.get_wikis()
-      for key in wikis.keys():
-          if wikis[key] not in use_wikis:
-              wikis[key] = "none"
-      wiki.set_wiki(wikis)
+        import wiki
+        wiki.toggle_keys(use_wikis)
     except ImportError:
-      print("Unable to import wiki functions. Is the file in your directory?")
+        print("Unable to import wiki functions. Is the file in your directory?")
 
 # Import subprocess
 bot = commands.Bot(command_prefix=".", intents=discord.Intents.default(),
@@ -85,7 +81,7 @@ async def ping(ctx):
 @bot.command()
 async def get_wiki(ctx, *args):
     if use_wiki_commands:
-        wiki(ctx, *args)
+        wiki.wiki(ctx, *args)
 
 @bot.command()
 async def invite(ctx):

--- a/bot.py
+++ b/bot.py
@@ -9,8 +9,9 @@ from discord.ext.commands import has_permissions, MissingPermissions
 from dotenv import load_dotenv
 import aiohttp
 from unidecode import unidecode
+from difflib import get_close_matches
 
-# import subprocess
+# Import subprocess
 
 bot = commands.Bot(command_prefix=".", intents=discord.Intents.default(),
                    case_insensitive=True)
@@ -25,6 +26,170 @@ logging.basicConfig(filename='console.log',
                     )
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
+"""
+    Wiki definitions
+    'wikis' contains number to function name mappings.
+    'wikialts' contains name to number mappings.
+    The dict keys in 'wikialts' are approximations to the inputted command.
+    We later search for the closest match in the dictionary.
+    e.g. 'example' points to 'wiki_example(*defs)' through wikialts and then wikis 
+
+    If you want to delete a plugin, remove its respective entries from 'wikis' and 'wikialts'.
+    It does not work if you only delete the index registry under wiki_<name>_pages
+"""
+wikis = {
+    # Name as in function (e.g. wiki_example() )
+    -1: 'example',
+    0: 'iris',
+    1: 'vehiclesplus',
+    2: 'react'
+}
+wikialts = {
+    # Example alts
+    'example': -1,
+    'exam': -1,
+    'ex': -1,
+
+    # Iris alts
+    'iris': 0,
+    'ir': 0,
+    'iri': 0,
+    'i': 0,
+
+    # VehiclesPlus alts
+    'vehiclesplus': 1,
+    'vp': 1,
+    'vehclesplus': 1,
+
+    # React alts
+    'react': 2,
+    're': 2,
+    'ract': 2,
+    'rea': 2
+}
+
+"""
+    _path describes the main directory path
+    _pages is a dictionary of all subsequent pages.
+        Keys should be the title of the page
+        Make sure to define "main" at least.
+"""
+wiki_example_path = 'https://docs.gitbook.com/'
+wiki_example_pages = {
+    "start exploring": "getting-started/start-exploring", # Real page for Gitbook
+    "main": "" # Main entry also points to main page
+}
+
+wiki_iris_path = 'https://volmitsoftware.gitbook.io/iris/'
+wiki_iris_pages = {
+    # Main
+    "main": "",
+    "intro": "",
+
+    "getting started": "getting-started",
+    "get started": "getting-started",
+    "started": "getting-started",
+
+
+
+    # Plugin category
+    "commands": "plugin/commands",
+    "cmd": "plugin/commands",
+
+    "permissions": "plugin/permissions",
+    "perms": "plugin/permissions",
+
+    "configuration": "plugin/configuration",
+    "config": "plugin/configuration",
+
+    "faq": "plugin/faq",
+    "frequently asked questions": "plugin/faq",
+
+
+
+    # Engine category
+    "introduction to the engine": "engine/introduction-to-the-engine",
+    "engine intro": "engine/introduction-to-the-engine",
+    "introduction": "engine/introduction-to-the-engine",
+
+    "studio": "engine/studio",
+    "studio intro": "engine/studio",
+    "std": "engine/studio",
+
+    "creating a new project": "engine/new-project",
+    "new project": "engine/new-project",
+    "project": "engine/new-project",
+
+    "understanding": "engine/understanding",
+    "understand": "engine/understanding",
+        # Understanding subcategory
+
+        "dimension": "engine/understanding/dimensions",
+        "dimensions": "engine/understanding/dimensions",
+        "dim": "engine/understanding/dimensions",
+
+        "region": "engine/understanding/regions",
+        "regions": "engine/understanding/regions",
+        "reg": "engine/understanding/regions",
+
+        "biome": "engine/understanding/biomes",
+        "biomes": "engine/understanding/biomes",
+        "bio": "engine/understanding/biomes",
+        
+        "generator": "engine/understanding/generators",
+        "generators": "engine/understanding/generators",
+        "gen": "engine/understanding/generators",
+        
+        "object": "engine/understanding/objects",
+        "objects": "engine/understanding/objects",
+        "obj": "engine/understanding/objects",
+        
+        "jigsaw": "engine/understanding/jigsaw",
+        "jig": "engine/understanding/jigsaw",
+        
+        "loot": "engine/understanding/loot",
+        
+        "entity": "engine/understanding/entities",
+        "entities": "engine/understanding/entities",
+        "ent": "engine/understanding/entities",
+
+    "mastering": "engine/mastering",
+    "master": "engine/mastering",
+        # Mastering subcategory
+
+        "mastering dimension": "engine/mastering/dimensions",
+        "mastering dimensions": "engine/mastering/dimensions",
+        "mastering dim": "engine/mastering/dimensions",
+
+        "mastering biome": "engine/mastering/biomes",
+        "mastering biomes": "engine/mastering/biomes",
+        "mastering bio": "engine/mastering/biomes",
+
+        "mastering universal": "engine/mastering/universal-parameters",
+        "universal": "engine/mastering/universal-parameters",
+        "universal parameters": "engine/mastering/universal-parameters",
+        "master universal": "engine/mastering/universal-parameters",
+
+    "packaging and publishing dimension": "engine/packaging-and-publishing",
+    "packaging and publishing": "engine/packaging-and-publishing",
+    "package and publish": "engine/packaging-and-publishing",
+    "package and publish dimension": "engine/packaging-and-publishing",
+    "publish dimension": "engine/packaging-and-publishing",
+    "upload dimension": "engine/packaging-and-publishing",
+
+    "updating the overworld": "engine/updateoverworld",
+    "update overworld": "engine/updateoverworld",
+    "updating overworld": "engine/updateoverworld"}
+
+wiki_react_path = 'https://volmitsoftware.gitbook.io/react/'
+wiki_react_pages = {
+    "main": "" # Main entry also points to main page
+}
+
+wiki_vehiclesplus_path = 'https://volmitsoftware.gitbook.io/vehiclesplus/'
+wiki_vehiclesplus_pages = {
+    "main": "" # Main entry also points to main page
+}
 
 @bot.event
 async def on_ready():
@@ -76,6 +241,93 @@ async def ping(ctx):
 async def invite(ctx):
     await ctx.send('Invite me with this link:\nhttps://discord.com/oauth2/authorize?client_id=801178754772500500&permissions=0&scope=bot')
 
+"""
+Used to get Iris wiki page index.
+Modify dictionaries "wikis" and "wikialts" to properly map.
+Note the example wiki.
+"""
+@bot.command()
+async def wiki(ctx, *args):
+    # Prevent passing no plugin or argument
+    if len(args) <= 1 or args[0] == 'help':
+        await ctx.send('Please specify the plugin & page you want to link e.g. `.wiki <name> main.' + 
+            '\nYou can also use `.wiki index <name>` to get the full index.')
+        return
+
+    # Send indexing if available
+    if args[0] == 'index':
+        close_match = get_close_matches(args[1], wikialts.keys(), 1, 0.4)[0] # Gets most likely wiki in dictionary
+        if len(close_match) == 0:
+            ctx.send('No match found for plugin entry. Please doublecheck.')
+            return
+        wiki = wikis[wikialts[close_match[0]]] # Finds actual wiki name as in function
+        indexing = "**{} index:**\n\n".format(wiki.capitalize())
+        for key in eval('wiki_{}_pages'):
+            indexing += " - {}\n".format(key)
+        indexing += "\nMain path: {}".format(eval("wiki_{}_path".format(wiki)))
+        ctx.send(indexing)
+
+    # Get wiki type and run respective function
+    close_match = get_close_matches(args[0], wikialts.keys(), 1, 0.4)[0] # Gets most likely wiki in dictionary
+    if len(close_match) == 0:
+        ctx.send('No match found for plugin entry. Please doublecheck.')
+        return
+    wiki = wikis[wikialts[close_match[0]]] # Finds actual wiki name as in function
+    result = eval('wiki_' + wiki + '({args[1]})') # Evaluates function
+    wiki = wiki.capitalize() # Make first letter caps
+    ctx.send('Match: {} |  Wiki page for {} is: \n{}.'.format(wiki, result['match'], result['url']))
+
+"""
+    Returns closest matched page to the specified command
+    To create a new entry, copy-paste the function and replace:
+    'example' with the name of your plugin everywhere, and
+    create new definitions at the top for the path and pages.
+    You find more examples there.
+"""
+async def wiki_example(page):
+    # Add path to url and find closest match to entry
+    url = wiki_example_path
+    match = get_close_matches(page, wiki_example_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {'url': url, 'match': match}
+
+async def wiki_iris(page):
+    # Add path to url and find closest match to entry
+    url = wiki_iris_path
+    match = get_close_matches(page, wiki_iris_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {url: url, match: match}
+
+async def wiki_vehiclesplus(page):
+    # Add path to url and find closest match to entry
+    url = wiki_vehiclesplus_path
+    match = get_close_matches(page, wiki_vehiclesplus_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {'url': url, 'match': match}
+    
+async def wiki_react(page):
+    # Add path to url and find closest match to entry
+    url = wiki_react_path
+    match = get_close_matches(page, wiki_react_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {'url': url, 'match': match}
+
 @bot.command(name="react", pass_context=True)
 @has_permissions(administrator=True)
 async def react(ctx, url, reaction):
@@ -87,7 +339,6 @@ async def react(ctx, url, reaction):
 for file_name in os.listdir('./cogs'):
     if file_name.endswith('.py'):
         bot.load_extension(f'cogs.{file_name[:-3]}')
-
 
 bot.run(token)
 

--- a/bot.py
+++ b/bot.py
@@ -9,10 +9,22 @@ from discord.ext.commands import has_permissions, MissingPermissions
 from dotenv import load_dotenv
 import aiohttp
 from unidecode import unidecode
-from difflib import get_close_matches
+
+# Toggle wiki command & functionality on or off
+use_wiki_commands = True # toggle
+use_wikis = ["example"]  # specific toggle (included => on)
+if use_wiki_commands:
+    try:
+      import wiki
+      wikis = wiki.get_wikis()
+      for key in wikis.keys():
+          if wikis[key] not in use_wikis:
+              wikis[key] = "none"
+      wiki.set_wiki(wikis)
+   except ImportError:
+      print("Unable to import wiki functions. Is the file in your directory?")
 
 # Import subprocess
-
 bot = commands.Bot(command_prefix=".", intents=discord.Intents.default(),
                    case_insensitive=True)
 
@@ -26,171 +38,6 @@ logging.basicConfig(filename='console.log',
                     )
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
-"""
-    Wiki definitions
-    'wikis' contains number to function name mappings.
-    'wikialts' contains name to number mappings.
-    The dict keys in 'wikialts' are approximations to the inputted command.
-    We later search for the closest match in the dictionary.
-    e.g. 'example' points to 'wiki_example(*defs)' through wikialts and then wikis 
-
-    If you want to delete a plugin, remove its respective entries from 'wikis' and 'wikialts'.
-    It does not work if you only delete the index registry under wiki_<name>_pages
-"""
-wikis = {
-    # Name as in function (e.g. wiki_example() )
-    -1: 'example',
-    0: 'iris',
-    1: 'vehiclesplus',
-    2: 'react'
-}
-wikialts = {
-    # Example alts
-    'example': -1,
-    'exam': -1,
-    'ex': -1,
-
-    # Iris alts
-    'iris': 0,
-    'ir': 0,
-    'iri': 0,
-    'i': 0,
-
-    # VehiclesPlus alts
-    'vehiclesplus': 1,
-    'vp': 1,
-    'vehclesplus': 1,
-
-    # React alts
-    'react': 2,
-    're': 2,
-    'ract': 2,
-    'rea': 2
-}
-
-"""
-    _path describes the main directory path
-    _pages is a dictionary of all subsequent pages.
-        Keys should be the title of the page
-        Make sure to define "main" at least.
-"""
-wiki_example_path = 'https://docs.gitbook.com/'
-wiki_example_pages = {
-    "start exploring": "getting-started/start-exploring", # Real page for Gitbook
-    "main": "" # Main entry also points to main page
-}
-
-wiki_iris_path = 'https://volmitsoftware.gitbook.io/iris/'
-wiki_iris_pages = {
-    # Main
-    "main": "",
-    "intro": "",
-
-    "getting started": "getting-started",
-    "get started": "getting-started",
-    "started": "getting-started",
-
-
-
-    # Plugin category
-    "commands": "plugin/commands",
-    "cmd": "plugin/commands",
-
-    "permissions": "plugin/permissions",
-    "perms": "plugin/permissions",
-
-    "configuration": "plugin/configuration",
-    "config": "plugin/configuration",
-
-    "faq": "plugin/faq",
-    "frequently asked questions": "plugin/faq",
-
-
-
-    # Engine category
-    "introduction to the engine": "engine/introduction-to-the-engine",
-    "engine intro": "engine/introduction-to-the-engine",
-    "introduction": "engine/introduction-to-the-engine",
-
-    "studio": "engine/studio",
-    "studio intro": "engine/studio",
-    "std": "engine/studio",
-
-    "creating a new project": "engine/new-project",
-    "new project": "engine/new-project",
-    "project": "engine/new-project",
-
-    "understanding": "engine/understanding",
-    "understand": "engine/understanding",
-        # Understanding subcategory
-
-        "dimension": "engine/understanding/dimensions",
-        "dimensions": "engine/understanding/dimensions",
-        "dim": "engine/understanding/dimensions",
-
-        "region": "engine/understanding/regions",
-        "regions": "engine/understanding/regions",
-        "reg": "engine/understanding/regions",
-
-        "biome": "engine/understanding/biomes",
-        "biomes": "engine/understanding/biomes",
-        "bio": "engine/understanding/biomes",
-        
-        "generator": "engine/understanding/generators",
-        "generators": "engine/understanding/generators",
-        "gen": "engine/understanding/generators",
-        
-        "object": "engine/understanding/objects",
-        "objects": "engine/understanding/objects",
-        "obj": "engine/understanding/objects",
-        
-        "jigsaw": "engine/understanding/jigsaw",
-        "jig": "engine/understanding/jigsaw",
-        
-        "loot": "engine/understanding/loot",
-        
-        "entity": "engine/understanding/entities",
-        "entities": "engine/understanding/entities",
-        "ent": "engine/understanding/entities",
-
-    "mastering": "engine/mastering",
-    "master": "engine/mastering",
-        # Mastering subcategory
-
-        "mastering dimension": "engine/mastering/dimensions",
-        "mastering dimensions": "engine/mastering/dimensions",
-        "mastering dim": "engine/mastering/dimensions",
-
-        "mastering biome": "engine/mastering/biomes",
-        "mastering biomes": "engine/mastering/biomes",
-        "mastering bio": "engine/mastering/biomes",
-
-        "mastering universal": "engine/mastering/universal-parameters",
-        "universal": "engine/mastering/universal-parameters",
-        "universal parameters": "engine/mastering/universal-parameters",
-        "master universal": "engine/mastering/universal-parameters",
-
-    "packaging and publishing dimension": "engine/packaging-and-publishing",
-    "packaging and publishing": "engine/packaging-and-publishing",
-    "package and publish": "engine/packaging-and-publishing",
-    "package and publish dimension": "engine/packaging-and-publishing",
-    "publish dimension": "engine/packaging-and-publishing",
-    "upload dimension": "engine/packaging-and-publishing",
-
-    "updating the overworld": "engine/updateoverworld",
-    "update overworld": "engine/updateoverworld",
-    "updating overworld": "engine/updateoverworld"}
-
-wiki_react_path = 'https://volmitsoftware.gitbook.io/react/'
-wiki_react_pages = {
-    "main": "" # Main entry also points to main page
-}
-
-wiki_vehiclesplus_path = 'https://volmitsoftware.gitbook.io/vehiclesplus/'
-wiki_vehiclesplus_pages = {
-    "main": "" # Main entry also points to main page
-}
-
 @bot.event
 async def on_ready():
     # Marks bot as running
@@ -203,32 +50,30 @@ async def on_ready():
 @bot.event
 async def on_message(message):
     # Binflop
-    if len(message.attachments) > 0:
-        if not message.attachments[0].url.endswith(
-                ('.png', '.jpg', '.jpeg', '.mp4', '.mov', '.avi', '.gif', '.image', '.svg')):
-            download = message.attachments[0].url
-            async with aiohttp.ClientSession() as session:
-                async with session.get(download, allow_redirects=True) as r:
+    if len(message.attachments) > 0 and not message.attachments[0].url.endswith(
+        ('.png', '.jpg', '.jpeg', '.mp4', '.mov', '.avi', '.gif', '.image', '.svg')):
+        download = message.attachments[0].url
+        async with aiohttp.ClientSession() as session:
+            async with session.get(download, allow_redirects=True) as r:
 
-                    # r = requests.get(download, allow_redirects=True)
-                    text = await r.text()
-                    text = unidecode(text)
-                    text = "\n".join(text.splitlines())
-                    if '�' not in text:  # If it's not an image/gif
-                        truncated = False
-                        if len(text) > 100000:
-                            text = text[:99999]
-                            truncated = True
-                        req = requests.post('https://bin.bloom.host/documents', data=text)
-                        key = json.loads(req.content)['key']
-                        response = ""
-                        response = response + "https://bin.bloom.host/" + key
-                        response = response + "\nRequested by " + message.author.mention
-                        if truncated:
-                            response = response + "\n(file was truncated because it was too long.)"
-                        embed_var = discord.Embed(title="Please use a paste service", color=0x1D83D4)
-                        embed_var.description = response
-                        await message.channel.send(embed=embed_var)
+                #. r = requests.get(download, allow_redirects=True)
+                text = await r.text()
+                text = unidecode(text)
+                text = "\n".join(text.splitlines())
+                if '�' not in text:  # If it's not an image/gif
+                    truncated = False
+                    if len(text) > 100000:
+                        text = text[:99999]
+                        truncated = True
+                    req = requests.post('https://bin.bloom.host/documents', data=text)
+                    key = json.loads(req.content)['key']
+                    response = "https://bin.bloom.host/" + key
+                    response += "\nRequested by " + message.author.mention
+                    if truncated:
+                        response += "\n(file was truncated because it was too long.)"
+                    embed_var = discord.Embed(title="Please use a paste service", color=0x1D83D4)
+                    embed_var.description = response
+                    await message.channel.send(embed=embed_var)
     timings = bot.get_cog('Timings')
     await timings.analyze_timings(message)
     await bot.process_commands(message)
@@ -238,95 +83,13 @@ async def ping(ctx):
     await ctx.send(f'Kahti bot ping is {round(bot.latency * 1000)}ms')
 
 @bot.command()
+async def get_wiki(ctx, *args):
+    if use_wiki_commands:
+        wiki(ctx, *args)
+
+@bot.command()
 async def invite(ctx):
     await ctx.send('Invite me with this link:\nhttps://discord.com/oauth2/authorize?client_id=801178754772500500&permissions=0&scope=bot')
-
-"""
-Used to get Iris wiki page index.
-Modify dictionaries "wikis" and "wikialts" to properly map.
-Note the example wiki.
-"""
-@bot.command()
-async def wiki(ctx, *args):
-    # Prevent passing no plugin or argument
-    if len(args) <= 1 or args[0] == 'help':
-        await ctx.send('Please specify the plugin & page you want to link e.g. `.wiki <name> main.' + 
-            '\nYou can also use `.wiki index <name>` to get the full index.')
-        return
-
-    # Send indexing if available
-    if args[0] == 'index':
-        close_match = get_close_matches(args[1], wikialts.keys(), 1, 0.4)[0] # Gets most likely wiki in dictionary
-        if len(close_match) == 0:
-            ctx.send('No match found for plugin entry. Please doublecheck.')
-            return
-        wiki = wikis[wikialts[close_match[0]]] # Finds actual wiki name as in function
-        indexing = "**{} index:**\n\n".format(wiki.capitalize())
-        for key in eval('wiki_{}_pages'):
-            indexing += " - {}\n".format(key)
-        indexing += "\nMain path: {}".format(eval("wiki_{}_path".format(wiki)))
-        ctx.send(indexing)
-
-    # Get wiki type and run respective function
-    close_match = get_close_matches(args[0], wikialts.keys(), 1, 0.4)[0] # Gets most likely wiki in dictionary
-    if len(close_match) == 0:
-        ctx.send('No match found for plugin entry. Please doublecheck.')
-        return
-    wiki = wikis[wikialts[close_match[0]]] # Finds actual wiki name as in function
-    result = eval('wiki_' + wiki + '({args[1]})') # Evaluates function
-    wiki = wiki.capitalize() # Make first letter caps
-    ctx.send('Match: {} |  Wiki page for {} is: \n{}.'.format(wiki, result['match'], result['url']))
-
-"""
-    Returns closest matched page to the specified command
-    To create a new entry, copy-paste the function and replace:
-    'example' with the name of your plugin everywhere, and
-    create new definitions at the top for the path and pages.
-    You find more examples there.
-"""
-async def wiki_example(page):
-    # Add path to url and find closest match to entry
-    url = wiki_example_path
-    match = get_close_matches(page, wiki_example_pages.keys(), 1, 0.4)
-
-    # Make sure a match was found
-    if len(match) == 0:
-        return 'no URL found, please doublecheck the page entry'
-    else:
-        return {'url': url, 'match': match}
-
-async def wiki_iris(page):
-    # Add path to url and find closest match to entry
-    url = wiki_iris_path
-    match = get_close_matches(page, wiki_iris_pages.keys(), 1, 0.4)
-
-    # Make sure a match was found
-    if len(match) == 0:
-        return 'no URL found, please doublecheck the page entry'
-    else:
-        return {url: url, match: match}
-
-async def wiki_vehiclesplus(page):
-    # Add path to url and find closest match to entry
-    url = wiki_vehiclesplus_path
-    match = get_close_matches(page, wiki_vehiclesplus_pages.keys(), 1, 0.4)
-
-    # Make sure a match was found
-    if len(match) == 0:
-        return 'no URL found, please doublecheck the page entry'
-    else:
-        return {'url': url, 'match': match}
-    
-async def wiki_react(page):
-    # Add path to url and find closest match to entry
-    url = wiki_react_path
-    match = get_close_matches(page, wiki_react_pages.keys(), 1, 0.4)
-
-    # Make sure a match was found
-    if len(match) == 0:
-        return 'no URL found, please doublecheck the page entry'
-    else:
-        return {'url': url, 'match': match}
 
 @bot.command(name="react", pass_context=True)
 @has_permissions(administrator=True)

--- a/wiki.py
+++ b/wiki.py
@@ -57,6 +57,12 @@ def set_wikis(wiki):
     global wikis
     wikis = wiki
 
+def toggle_keys(keys):
+    for key in wikis.keys():
+        if wikis[key] not in keys:
+            wikis[key] = "none"
+    wiki.set_wiki(wikis)
+
 """ Wiki variable description
     _path describes the main directory path
     _pages is a dictionary of all subsequent pages.

--- a/wiki.py
+++ b/wiki.py
@@ -1,0 +1,270 @@
+"""
+This is the file where you add wiki pages with URLs and plugin command alts.
+This can be omitted, in which case none of these functions will be available.
+All command functionality is included in this file.
+
+Feel free to add more indexes, command alts, and other plugins' wikis altogether.
+"""
+
+from difflib import get_close_matches
+
+
+""" Wiki definitions
+    'wikis' contains number to function name mappings.
+    'wikialts' contains name to number mappings.
+    The dict keys in 'wikialts' are approximations to the inputted command.
+    We later search for the closest match in the dictionary.
+    e.g. 'example' points to 'wiki_example(*defs)' through wikialts and then wikis 
+
+    If you want to delete a plugin, remove its respective entries from 'wikis' and 'wikialts'.
+    It does not work if you only delete the index registry under wiki_<name>_pages
+"""
+wikis = {
+    # Name as in function (e.g. wiki_example() )
+    -1: 'example',
+    0: 'iris',
+    1: 'vehiclesplus',
+    2: 'react'
+}
+wikialts = {
+    # Example alts
+    'example': -1,
+    'exam': -1,
+    'ex': -1,
+
+    # Iris alts
+    'iris': 0,
+    'ir': 0,
+    'iri': 0,
+    'i': 0,
+
+    # VehiclesPlus alts
+    'vehiclesplus': 1,
+    'vp': 1,
+    'vehclesplus': 1,
+
+    # React alts
+    'react': 2,
+    're': 2,
+    'ract': 2,
+    'rea': 2
+}
+
+def get_wikis():
+    return wikis
+
+def set_wikis(wiki):
+    global wikis
+    wikis = wiki
+
+""" Wiki variable description
+    _path describes the main directory path
+    _pages is a dictionary of all subsequent pages.
+        Keys should be the title of the page
+        Make sure to define "main" at least.
+"""
+wiki_example_path = 'https://docs.gitbook.com/'
+wiki_example_pages = {
+    "start exploring": "getting-started/start-exploring", # Real page for Gitbook
+    "main": "" # Main entry also points to main page
+}
+
+wiki_iris_path = 'https://volmitsoftware.gitbook.io/iris/'
+wiki_iris_pages = {
+    # Main
+    "main": "",
+    "intro": "",
+
+    "getting started": "getting-started",
+    "get started": "getting-started",
+    "started": "getting-started",
+
+
+
+    # Plugin category
+    "commands": "plugin/commands",
+    "cmd": "plugin/commands",
+
+    "permissions": "plugin/permissions",
+    "perms": "plugin/permissions",
+
+    "configuration": "plugin/configuration",
+    "config": "plugin/configuration",
+
+    "faq": "plugin/faq",
+    "frequently asked questions": "plugin/faq",
+
+
+
+    # Engine category
+    "introduction to the engine": "engine/introduction-to-the-engine",
+    "engine intro": "engine/introduction-to-the-engine",
+    "introduction": "engine/introduction-to-the-engine",
+
+    "studio": "engine/studio",
+    "studio intro": "engine/studio",
+    "std": "engine/studio",
+
+    "creating a new project": "engine/new-project",
+    "new project": "engine/new-project",
+    "project": "engine/new-project",
+
+    "understanding": "engine/understanding",
+    "understand": "engine/understanding",
+        # Understanding subcategory
+
+        "dimension": "engine/understanding/dimensions",
+        "dimensions": "engine/understanding/dimensions",
+        "dim": "engine/understanding/dimensions",
+
+        "region": "engine/understanding/regions",
+        "regions": "engine/understanding/regions",
+        "reg": "engine/understanding/regions",
+
+        "biome": "engine/understanding/biomes",
+        "biomes": "engine/understanding/biomes",
+        "bio": "engine/understanding/biomes",
+        
+        "generator": "engine/understanding/generators",
+        "generators": "engine/understanding/generators",
+        "gen": "engine/understanding/generators",
+        
+        "object": "engine/understanding/objects",
+        "objects": "engine/understanding/objects",
+        "obj": "engine/understanding/objects",
+        
+        "jigsaw": "engine/understanding/jigsaw",
+        "jig": "engine/understanding/jigsaw",
+        
+        "loot": "engine/understanding/loot",
+        
+        "entity": "engine/understanding/entities",
+        "entities": "engine/understanding/entities",
+        "ent": "engine/understanding/entities",
+
+    "mastering": "engine/mastering",
+    "master": "engine/mastering",
+        # Mastering subcategory
+
+        "mastering dimension": "engine/mastering/dimensions",
+        "mastering dimensions": "engine/mastering/dimensions",
+        "mastering dim": "engine/mastering/dimensions",
+
+        "mastering biome": "engine/mastering/biomes",
+        "mastering biomes": "engine/mastering/biomes",
+        "mastering bio": "engine/mastering/biomes",
+
+        "mastering universal": "engine/mastering/universal-parameters",
+        "universal": "engine/mastering/universal-parameters",
+        "universal parameters": "engine/mastering/universal-parameters",
+        "master universal": "engine/mastering/universal-parameters",
+
+    "packaging and publishing dimension": "engine/packaging-and-publishing",
+    "packaging and publishing": "engine/packaging-and-publishing",
+    "package and publish": "engine/packaging-and-publishing",
+    "package and publish dimension": "engine/packaging-and-publishing",
+    "publish dimension": "engine/packaging-and-publishing",
+    "upload dimension": "engine/packaging-and-publishing",
+
+    "updating the overworld": "engine/updateoverworld",
+    "update overworld": "engine/updateoverworld",
+    "updating overworld": "engine/updateoverworld"}
+
+wiki_react_path = 'https://volmitsoftware.gitbook.io/react/'
+wiki_react_pages = {
+    "main": "" # Main entry also points to main page
+}
+
+wiki_vehiclesplus_path = 'https://volmitsoftware.gitbook.io/vehiclesplus/'
+wiki_vehiclesplus_pages = {
+    "main": "" # Main entry also points to main page
+}
+
+
+
+"""
+Used to get wiki page index.
+Modify dictionaries "wikis" and "wikialts" to properly map.
+Note the example wiki.
+"""
+async def wiki(ctx, *args):
+    # Prevent passing no plugin or argument
+    if len(args) <= 1 or args[0] == 'help':
+        await ctx.send('Please specify the plugin & page you want to link e.g. `.wiki <name> main.' + 
+            '\nYou can also use `.wiki index <name>` to get the full index.')
+        return
+
+    # Send indexing if available
+    if args[0] == 'index':
+        close_match = get_close_matches(args[1], wikialts.keys(), 1, 0.4)[0] # Gets most likely wiki in dictionary
+        if len(close_match) == 0 or close_match == 'none':
+            ctx.send('No match found for plugin entry. Please doublecheck.')
+            return
+        wiki = wikis[wikialts[close_match[0]]] # Finds actual wiki name as in function
+        indexing = "**{} index:**\n\n".format(wiki.capitalize())
+        for key in eval('wiki_{}_pages'):
+            indexing += " - {}\n".format(key)
+        indexing += "\nMain path: {}".format(eval("wiki_{}_path".format(wiki)))
+        ctx.send(indexing)
+
+    # Get wiki type and run respective function
+    close_match = get_close_matches(args[0], wikialts.keys(), 1, 0.4)[0] # Gets most likely wiki in dictionary
+    if len(close_match) == 0:
+        ctx.send('No match found for plugin entry. Please doublecheck.')
+        return
+    wiki = wikis[wikialts[close_match[0]]] # Finds actual wiki name as in function
+    result = eval('wiki_' + wiki + '({args[1]})') # Evaluates function
+    wiki = wiki.capitalize() # Make first letter caps
+    ctx.send('Match: {} |  Wiki page for {} is: \n{}.'.format(wiki, result['match'], result['url']))
+
+
+
+""" Returns closest matched page to the specified command
+    To create a new entry, copy-paste the function and replace:
+    'example' with the name of your plugin everywhere, and
+    create new definitions at the top for the path and pages.
+    You find more examples there.
+"""
+async def wiki_example(page):
+    # Add path to url and find closest match to entry
+    url = wiki_example_path
+    match = get_close_matches(page, wiki_example_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {'url': url, 'match': match}
+
+async def wiki_iris(page):
+    # Add path to url and find closest match to entry
+    url = wiki_iris_path
+    match = get_close_matches(page, wiki_iris_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {url: url, match: match}
+
+async def wiki_vehiclesplus(page):
+    # Add path to url and find closest match to entry
+    url = wiki_vehiclesplus_path
+    match = get_close_matches(page, wiki_vehiclesplus_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {'url': url, 'match': match}
+    
+async def wiki_react(page):    
+    # Add path to url and find closest match to entry
+    url = wiki_react_path
+    match = get_close_matches(page, wiki_react_pages.keys(), 1, 0.4)
+
+    # Make sure a match was found
+    if len(match) == 0:
+        return 'no URL found, please doublecheck the page entry'
+    else:
+        return {'url': url, 'match': match}


### PR DESCRIPTION
Adds new commands which you can easily modify.
Well documented.

Command:
.wiki
Parameters:
index <pluginname>  # Prints a full index including alts. Will be fixed later.
<pluginname> <page> # Prints a link to the wiki page of that plugin as indexed.